### PR TITLE
Add glossary of terms commonly used within our service

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -1,6 +1,6 @@
 {% extends "govuk/template.njk" %}
 
-{% set htmlClasses = 'no-js' %}
+{% set htmlClasses = "no-js" %}
 
 {% from "header/macro.njk" import appHeader %}
 {% from "breadcrumbs/macro.njk" import appBreadcrumbs %}
@@ -38,16 +38,18 @@
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
 {% block footer %}
-  <div class="govuk-!-display-none-print">
-    {{ govukFooter({
-      meta: {
-        items: [{
-          text: "Sitemap",
-          href: "/sitemap"
-        }]
-      }
-    }) }}
-  </div>
+  {{ govukFooter({
+    classes: "govuk-!-display-none-print",
+    meta: {
+      items: [{
+        text: "Glossary",
+        href: "/glossary"
+      }, {
+        text: "Sitemap",
+        href: "/sitemap"
+      }]
+    }
+  }) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/app/glossary.md
+++ b/app/glossary.md
@@ -1,0 +1,152 @@
+---
+layout: page
+title: A to Z glossary
+description: A collection of terms commonly used within our service.
+eleventyExcludeFromCollections: true
+---
+
+A collection of terms commonly used within our service.
+
+## A
+
+Affordable Rent
+: Properties let as part of the [Affordable Homes Programme](https://www.gov.uk/government/collections/affordable-homes-programme-2021-to-2026) where rents of up to 80% of market rent can be charged.
+
+Analysis and Data Directorate (ADD)
+: A key set of stakeholders relating to CORE data and surrounding systems.
+
+Assignment
+: The transfer of tenancy from a sole tenant to another person. This is the result of a request from the sole tenant to hand over their tenancy rather than as a result of the death of the tenant.
+
+## C
+
+Choice-based letting (CBL)
+: An allocation system where vacancies are advertised through media such as local newspapers, a website, or through targeted direct mail. Households registered with the scheme are able to bid for specific properties that match their assessed requirements. Applications for each property are ranked according to the applicant prioritisation criteria published, and the property is offered to the applicant with the highest priority.
+
+CIH
+: The [Chartered Institute of Housing](https://www.cih.org) is the professional body for those working in the housing profession in the United Kingdom. It has a royal charter, gained in 1984.
+
+Common Allocations Policy (CAP)
+: A single allocation system for prioritising applicants used by 2 or more Registered Providers.
+
+Common Housing Register (CHR)
+: A single waiting list set up by Registered Providers to receive and process housing applications.
+
+CORE
+: The service we are building. [CORE](https://core.communities.gov.uk) (COntinuous REcording of Lettings and Sales in Social Housing in England) provides valuable information about new social housing lettings, sales, tenants and buyers across England. This information is used by government bodies and organisations to inform social housing funding, regulatory and housing policy decisions.
+
+Clip-H
+: The central and local government forum for discussing housing collections data.
+
+## D
+
+Decants
+: Housing held vacant to accommodate tenants whose properties are due to become uninhabitable because of improvement, repair or other work. These can be used to rehouse tenants permanently or temporarily until the tenant can return to their former home.
+
+Department for Levelling Up, Housing and Communities (DLUHC)
+: The ministerial department that funds CORE. Previously known as the Ministry of Housing, Communities & Local Government (MHCLG), and before that the Department of Communities & Local Government (DCLG).
+
+## E
+
+E-Core
+: The bulk upload options on CORE.
+
+## G
+
+General Needs housing
+: Housing stock that is not designated for specific groups that require support.
+
+GLA
+: Greater London Authority.
+
+## H
+
+Housemark
+: Housemark is a commercial company owned by 2 charities (the Chartered Institute of Housing and the National Housing Federation). They provide a benchmarking product used by large housing associations and local authorities.
+
+Housing association (HA)
+: A housing association offers similar types of housing as a local council, often to people on a low income or who need extra support. Any housing association registered with the Regulator for Social Housing is required to complete CORE lettings logs fully and accurately.
+
+H-CLIC (Homelessness Case Level Collection)
+: [Details on homelessness data](https://gss.civilservice.gov.uk/user-facing-pages/mhclg-homelessness-statistics-user-forum/).
+
+## I
+
+Intermediate Rent
+: A sub-market rent where the rent must not exceed 80% of the current market rate (inclusive of service charge). This can include schemes with specific eligibility criteria, the reduced rent is an opportunity for the tenant to save towards a house purchasing deposit. As part of the intermediate rent arrangement there may also be a future opportunity to purchase the property (or a share of the property) currently being rented.
+
+## L
+
+LA
+: Local authority.
+
+LAHS
+: [Local authority housing statistics](https://www.gov.uk/government/collections/local-authority-housing-data). Used by central and local government to have an understanding of its housing situation and how policies affect it.
+
+Local Digital Collaboration Unit (LDCU)
+: The [Local Digital Collaboration Unit](https://www.localdigital.gov.uk) is a DLUHC team aiming to drive interoperability standards and design patterns across local digital services.
+
+London Affordable Rent
+: A tenure of affordable housing made available in London by the GLA.
+
+London Living Rent
+: A tenure of affordable housing available in London by the GLA.
+
+## M
+
+Market rented housing
+: Properties let on assured shorthold tenancies, where the rent is comparable to privately rented properties in the location, and there is no public subsidy.
+
+## N
+
+National Housing Federation (NHF)
+: The [National Housing Federation](https://www.housing.org.uk) is a trade association for member social housing providers in England.
+
+## P
+
+Private Registered Provider (PRP)
+: See Housing association.
+
+## R
+
+Reasonable preference
+: Am allocation policy used by councils to give priority to certain groups of people. Each council can decide who else gets priority within its area, and how much priority they get.
+
+Registered Provider
+: Any provider registered with the Regulator of Social Housing (RSH). Local Authorities (LAs) and Private Registered Providers (PRPs) are required to complete CORE lettings logs. Social landlords not registered but affiliated to the National Housing Federation (NHF) are invited to complete CORE logs.
+
+Regulator of Social Housing (RSH)
+: The [Regulator of Social Housing](https://www.gov.uk/government/organisations/regulator-of-social-housing) regulates registered providers of social housing to promote a viable, efficient and well-governed social housing sector able to deliver homes that meet a range of needs.
+
+Renewal
+: A fixed-term tenancy that is renewed to the same tenant at the same property.
+
+Rent to Buy
+: Properties where a discount of up to 20% of market rent is charged for a single rental period of between 6 months and 5 years. During and after that period, the tenant is offered first chance to purchase the property (either shared ownership or outright) at full market value. These are only available from PRPs.
+
+## S
+
+Single data list
+: The [single data list](https://www.gov.uk/government/publications/single-data-list) is a list of all the datasets that local government must submit to central government.
+
+Sheltered accommodation
+: Housing designated for occupation by older people (often 55 years or older) with care and support needs. It is split into ‘sheltered housing’ for people with low level care needs and ‘extra care housing’ for people with medium to high care needs.
+
+Social housing
+: Social housing is any housing scheme where accommodation is provided by a housing association or local council. Social homes have rents pegged to local incomes and provide an affordable, secure housing option for people across the country.
+
+Succession
+: If a tenant dies, their spouse may have the right to take over the tenancy – as long as they occupied the property as their only or principal home at the time of the tenant’s death. If there is no spouse, a family member who has lived in the home for at least 12 months before the tenant’s death may have the right to succeed.
+
+Supported housing
+: Supported housing is any housing scheme where accommodation is provided alongside care, support or supervision to help people live as independently as possible in the community. Schemes are usually run by local authorities, housing associations or voluntary groups.
+
+## U
+
+UPRN
+: Unique Property Reference Number.
+
+## V
+
+Void period
+: How long a property has been vacant for.


### PR DESCRIPTION
Beginnings of a glossary page, a place to capture abbreviations, names and terms commonly used within the CORE service.

Most of these have been sourced from [the CORE manual](https://core.communities.gov.uk/public/download/guides-and-manuals/CORE%20Manual%202021-22.pdf?download-format=pdf), the [Acronyms and Terminology](https://digital.dclg.gov.uk/confluence/display/MC/Acronyms+and+Terminology) page on Confluence, and [GOV.UK](https://gov.uk).